### PR TITLE
Clarification on start object being reset for each group

### DIFF
--- a/draft-afrind-moq-test.md
+++ b/draft-afrind-moq-test.md
@@ -68,7 +68,8 @@ This field specifies the starting group number for the track.  The default value
 
 ## Tuple Field 3: Start Object
 
-This field specifies the starting object number for each group in the track.  The default value is 0.
+This field specifies the starting object number for each group in the track.
+The default value is 0.
 
 ## Tuple Field 4: Last Group in Track
 

--- a/draft-afrind-moq-test.md
+++ b/draft-afrind-moq-test.md
@@ -68,7 +68,7 @@ This field specifies the starting group number for the track.  The default value
 
 ## Tuple Field 3: Start Object
 
-This field specifies the starting object number for the track.  The default value is 0.
+This field specifies the starting object number for each group in the track.  The default value is 0.
 
 ## Tuple Field 4: Last Group in Track
 


### PR DESCRIPTION
Previously, there was some ambiguity as to whether the object ids get reset at the beginning of each group. For example, if start_object == 0 and object_increment == 1 and objects_per_group == 3, there was ambiguity as to whether things would look like:

Group 0: 0, 1, 2
Group 1: 3, 4, 5
...

OR

Group 0: 0, 1, 2
Group 1: 0, 1, 2
...