### PR TITLE
Clarify Two subgroups with even Object Increment

### DIFF
--- a/draft-afrind-moq-test.md
+++ b/draft-afrind-moq-test.md
@@ -60,7 +60,8 @@ This field specifies the forwarding preference for the track. The following valu
 * 2 := Two subgroups per group (0 and 1)
 * 3 := Datagram
 
-The default value is 0.  When using two subgroups per group, even numbered objects are sent on subgroup 0 and odd numbered objects are sent on group 1.
+The default value is 0.  When using two subgroups per group, even numbered objects are sent on subgroup 0 and odd numbered objects are sent on subgroup 1.
+When Object Increment is even, objects will only be sent on one of the two streams.  The publisher MAY open the unused subgroup stream for each group.
 
 ## Tuple Field 2: Start Group
 


### PR DESCRIPTION
The existing language was slightly ambiguous.  I intended it to mean "even object IDs -> subgroup 0".  I hadn't thought about the intersection with even object increment, which leaves one stream unused.

Now that I think about it, I'm maybe it's better the other way, where the first object sent goes on subgroup 0, second object sent goes on subgroup 1, etc.